### PR TITLE
[BOJ/실버1] 22-10-15 (쉬운 계단 수)

### DIFF
--- a/hyesu/DP/10844.py
+++ b/hyesu/DP/10844.py
@@ -1,0 +1,19 @@
+# 쉬운 계단수
+
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+
+d = [[1] * 10 for _ in range(n)]
+
+for i in range(1, n):
+    for j in range(10):
+        if j == 0:
+            d[i][j] = d[i-1][1]
+        elif j == 9:
+            d[i][j] = d[i-1][8]
+        else:
+            d[i][j] = d[i-1][j-1] + d[i-1][j+1]
+
+print((sum(d[n-1]) - d[n-1][0]) %1000000000)


### PR DESCRIPTION
<!-- PR 제목예시: [SWEA] 22-10-06 (N줄 덧셈) -->

## 🌱 문제번호와 링크

<!-- 문제번호와 링크를 간단히 적어주세요 -->


https://www.acmicpc.net/problem/10844

## 🥺 무엇을 알게 되었나요?

<!-- 오늘 알게된 내용을 간단히 적어주세요 -->

계단수는 2차원 배열을 이용한다. d[i][j] : i번째 자리수의 j(0~9)
맨 앞자리수의 0은 없다. 하지만 다음 번째 자리수의 0을 위해서는 미리 계산을 해놓긴 해야하는데, 
마지막에 출력할때는 맨앞자리 0이 없다고 생각해야 하기때문에 빼줘야함
`d[구하려는 n번째자리수]`의 전체합`(sum(d[n-1]) - d[n-1][0])`


<img width="400" alt="스크린샷 2022-10-15 오후 8 09 03" src="https://user-images.githubusercontent.com/68391767/195983280-7dd06d12-5076-46d4-824a-10353cd938c2.png">
