### PR TITLE
[BOJ/골드5] 22-10-17 (내려가기)

### DIFF
--- a/hyesu/DP/2096.py
+++ b/hyesu/DP/2096.py
@@ -1,0 +1,31 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+
+maxdp = [0, 0, 0]
+mindp = [0, 0, 0]
+
+score = []
+
+for _ in range(n):
+    a, b, c = map(int, input().split())
+    score.append((a, b, c))
+
+for i in range(n):
+    tmpMax = [0, 0, 0]
+    tmpMin = [0, 0, 0]
+    for j in range(3):
+        if j == 0:
+            tmpMax[j] = max(maxdp[0], maxdp[1]) + score[i][j]
+            tmpMin[j] = min(mindp[0], mindp[1]) + score[i][j]
+        elif j == 2:
+            tmpMax[j] = max(maxdp[1], maxdp[2]) + score[i][j]
+            tmpMin[j] = min(mindp[1], mindp[2]) + score[i][j]
+        else:
+            tmpMax[j] = max(maxdp) + score[i][j]
+            tmpMin[j] = min(mindp) + score[i][j]
+    maxdp = tmpMax
+    mindp = tmpMin
+        
+print(max(maxdp), min(mindp))


### PR DESCRIPTION
<!-- PR 제목예시: [SWEA] 22-10-06 (N줄 덧셈) -->

## 🌱 문제번호와 링크

<!-- 문제번호와 링크를 간단히 적어주세요 -->

https://www.acmicpc.net/problem/2096

## 🥺 무엇을 알게 되었나요?

<!-- 오늘 알게된 내용을 간단히 적어주세요 -->

처음에 2차원 배열 dp를 두개(max, min)만들어서 모든 값을 메모이제이션 했더니 메모리 초과가 났다.
``` python
import sys
input = sys.stdin.readline

n = int(input())

maxdp = [[0]*3 for _ in range(n)]
mindp = [[0]*3 for _ in range(n)]

score = []

for _ in range(n):
    a, b, c = map(int, input().split())
    score.append((a, b, c))


for i in range(n):
    for j in range(3):
        if j == 0:
            maxdp[i][j] = max(maxdp[i-1][0], maxdp[i-1][1]) + score[i][j]
            mindp[i][j] = min(mindp[i-1][0], mindp[i-1][1]) + score[i][j]
        elif j == 2:
            maxdp[i][j] = max(maxdp[i-1][1], maxdp[i-1][2]) + score[i][j]
            mindp[i][j] = min(mindp[i-1][1], mindp[i-1][2]) + score[i][j]
        else:
            maxdp[i][j] = max(maxdp[i-1]) + score[i][j]
            mindp[i][j] = min(mindp[i-1]) + score[i][j]

print(max(maxdp[n-1]), min(mindp[n-1]))
```

문제를 잘 읽어보면 메모리 제한이 4mb로 매우 적은 양이다. ..
그럼 저렇게 배열을 만들면 안된다는 건데,,
이 문제는 조금만 더 생각해보면 사실 옛날값까지 가지고 있을 필요가 없다.
그래서 굳이 2차원 배열로 모든 값을 저장하고 있지 않아도 된다.
그래서 현재 값만 maxdp, mindp에 저장해주는 걸로 바꿨다. 
``` python
maxdp = [0, 0, 0]
mindp = [0, 0, 0]
```

그리고 for문을 돌면서 현재 가장 큰값, 현재 가장 작은 값을 저 배열에 저장해줬다!

tmp배열을 만든 이유는 바로바로 maxdp, mindp에 저장해버리면 만약 0번째 자리 -> 1번째자리 계산하게 되면 0번째자리가 이미 갱신되어버린 값이기 때문에 1번째자리 값이 제대로 안나온다, , ,, 그렇기 때문에 한 줄이 모두 끝나고 나서야 값을 갱신해줘야 한다! 이때 한 줄이 끝날때까지 임시 저장소를 가지고 있으려고 tmp배열을 사용했다.

