### PR TITLE
[BOJ] 22-10-20 (미로 탐색)

### DIFF
--- a/minjung/백준/2178.py
+++ b/minjung/백준/2178.py
@@ -1,0 +1,28 @@
+from collections import deque
+
+
+def bfs(x,y):
+    if miro[x][y] == 1:
+        queue = deque([[x,y]])
+        while queue:
+            x,y = queue.popleft()
+            for i in range(4):
+                nx,ny = x+dx[i], y+dy[i]
+                if 0<=ny<m and 0<=nx<n and  miro[nx][ny]==1:
+                    miro[nx][ny] += miro[x][y]
+                    queue.append([nx,ny])
+
+
+
+
+
+n, m = map(int,(input().split()))
+dx = [0,1,0,-1]
+dy = [-1,0,1,0]
+
+miro =[list(map(int,input())) for _ in range(n)]
+
+
+
+bfs(0,0)
+print(miro[n-1][m-1])


### PR DESCRIPTION

## 🌱 문제번호와 링크

[[2187] 미로 탐색(BOJ/Silver1)](https://www.acmicpc.net/problem/2178)

## 🥺 무엇을 알게 되었나요?

최단경로 ->무조건 BFS
큐 선언시 deque((x,y))로 하면 unpacked 오류 남 , 배열에 담아서 deque([[x,y,]])로 선언해주기
