### PR TITLE
[BOJ] 22-10-23 (토마토) 

### DIFF
--- a/minjung/백준/7576.py
+++ b/minjung/백준/7576.py
@@ -1,0 +1,38 @@
+from collections import deque
+
+queue = deque([])
+def bfs():
+    
+    d = [(-1,0),(1,0),(0,1),(0,-1)]
+    while queue:
+        x,y = queue.popleft()
+        for dx,dy in d:
+            nx, ny = x+dx, y+dy
+            cnt = 1
+            if (0<=nx<N) and (0<=ny<M) and tomato[nx][ny] == 0:
+                tomato[nx][ny] = tomato[x][y]+1
+                queue.append([nx,ny])
+                
+
+    
+M, N = map(int,input().split())
+
+tomato = [list(map(int,input().split())) for _ in range(N)]
+res = []
+for i in range(N):
+    for j in range(M):
+        if tomato[i][j] == 1 :
+            queue.append([i,j])
+answer = -1e9
+
+bfs()
+
+for i in range(N):
+    for j in range(M):
+        if (tomato[i][j] == 0):
+            print('-1')
+            exit(0)
+    answer = max(answer,max(tomato[i])) 
+
+            
+print(answer - 1)

--- a/minjung/백준/tempCodeRunnerFile.py
+++ b/minjung/백준/tempCodeRunnerFile.py
@@ -1,2 +1,2 @@
 
-    while queue:
+            cnt = 1


### PR DESCRIPTION
## 🌱 문제번호와 링크

[[7576] 토마토 (BOJ/Gold5)](https://www.acmicpc.net/problem/7576)

## 🥺 무엇을 알게 되었나요?

1. 시작점이 여러개인 BFS 고려,, 
시작점이 여러개일 경우 조건에 따라 시작점을 전부 queue에 담아두고 BFS 시작 

2. 총 몇번의 BFS가 돌아갔는가 ? 같은 횟수를 고려할때 새로운 visited 배열 생성보다는 기존의 배열에서  새로운 배열값 += 기존의 배열값 으로 해야함  
`
if (0<=nx<N) and (0<=ny<M) and tomato[nx][ny] == 0:
                tomato[nx][ny] = tomato[x][y]+1
                queue.append([nx,ny])
`
